### PR TITLE
option to add search to the manifest

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -385,8 +385,7 @@ return [
             'iiifserver_image_max_size' => 10000000,
             'iiifserver_image_tile_dir' => 'tile',
             'iiifserver_image_tile_type' => 'deepzoom',
-            'iiifserver_manifest_service_iiifSearch' => '',
-            'iiifserver_manifest_service_iiifSearch_extractOcr' => false,
+            'iiifserver_manifest_service_iiifsearch' => '',
         ],
     ],
 ];

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -386,6 +386,7 @@ return [
             'iiifserver_image_tile_dir' => 'tile',
             'iiifserver_image_tile_type' => 'deepzoom',
             'iiifserver_manifest_service_iiifSearch' => '',
+            'iiifserver_manifest_service_iiifSearch_extractOcr' => false,
         ],
     ],
 ];

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -385,6 +385,7 @@ return [
             'iiifserver_image_max_size' => 10000000,
             'iiifserver_image_tile_dir' => 'tile',
             'iiifserver_image_tile_type' => 'deepzoom',
+            'iiifserver_manifest_service_iiifSearch' => '',
         ],
     ],
 ];

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -213,6 +213,15 @@ class ConfigForm extends Form implements TranslatorAwareInterface
             ],
         ]);
 
+        $manifestFieldset->add([
+            'name' => 'iiifserver_manifest_service_iiifSearch',
+            'type' => Element\Url::class,
+            'options' => [
+                'label' => 'IIIF Search url', // @translate
+                'info' => 'If any, this url to IIIF Search API will be used in search service and display search bar in the bottom panel of the Universal Viewer.',  // @translate
+            ],
+        ]);
+
         $this->add([
             'name' => 'iiifserver_image',
             'type' => Fieldset::class,
@@ -360,6 +369,10 @@ class ConfigForm extends Form implements TranslatorAwareInterface
         ]);
         $manifestFilter->add([
             'name' => 'iiifserver_manifest_force_url_to',
+            'required' => false,
+        ]);
+        $manifestFilter->add([
+            'name' => 'iiifserver_manifest_service_iiifSearch',
             'required' => false,
         ]);
 

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -214,24 +214,13 @@ class ConfigForm extends Form implements TranslatorAwareInterface
         ]);
 
         $manifestFieldset->add([
-            'name' => 'iiifserver_manifest_service_iiifSearch',
+            'name' => 'iiifserver_manifest_service_iiifsearch',
             'type' => Element\Url::class,
             'options' => [
                 'label' => 'IIIF Search url', // @translate
                 'info' => 'If any, this url to IIIF Search API will be used in search service and display search bar in the bottom panel of the Universal Viewer.',  // @translate
             ],
         ]);
-
-        $manifestFieldset->add([
-            'name' => 'iiifserver_manifest_service_iiifSearch_extractOcr',
-            'type' => Element\Checkbox::class,
-            'options' => [
-                'label' => 'IIIF Search provided by ExtractOcr module', // @translate
-                'info' => 'If you use IiifSearch & ExtractOcr modules to provide IiifSearch results, check this box to disable the search box when there is no OCR.',  // @translate
-            ],
-        ]);
-
-
 
         $this->add([
             'name' => 'iiifserver_image',
@@ -383,11 +372,7 @@ class ConfigForm extends Form implements TranslatorAwareInterface
             'required' => false,
         ]);
         $manifestFilter->add([
-            'name' => 'iiifserver_manifest_service_iiifSearch',
-            'required' => false,
-        ]);
-        $manifestFilter->add([
-            'name' => 'iiifserver_manifest_service_iiifSearch_extractOcr',
+            'name' => 'iiifserver_manifest_service_iiifsearch',
             'required' => false,
         ]);
 

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -222,6 +222,17 @@ class ConfigForm extends Form implements TranslatorAwareInterface
             ],
         ]);
 
+        $manifestFieldset->add([
+            'name' => 'iiifserver_manifest_service_iiifSearch_extractOcr',
+            'type' => Element\Checkbox::class,
+            'options' => [
+                'label' => 'IIIF Search provided by ExtractOcr module', // @translate
+                'info' => 'If you use IiifSearch & ExtractOcr modules to provide IiifSearch results, check this box to disable the search box when there is no OCR.',  // @translate
+            ],
+        ]);
+
+
+
         $this->add([
             'name' => 'iiifserver_image',
             'type' => Fieldset::class,
@@ -375,6 +386,11 @@ class ConfigForm extends Form implements TranslatorAwareInterface
             'name' => 'iiifserver_manifest_service_iiifSearch',
             'required' => false,
         ]);
+        $manifestFilter->add([
+            'name' => 'iiifserver_manifest_service_iiifSearch_extractOcr',
+            'required' => false,
+        ]);
+
 
         $imageFilter = $inputFilter->get('iiifserver_image');
         $imageFilter->add([

--- a/src/View/Helper/IiifManifest.php
+++ b/src/View/Helper/IiifManifest.php
@@ -158,6 +158,17 @@ class IiifManifest extends AbstractHelper
 
         $manifest['logo'] = $this->view->setting('iiifserver_manifest_logo_default');
 
+        $iiifSearch = $this->view->setting('iiifserver_manifest_service_iiifSearch');
+        if ( $iiifSearch ) {
+            $manifest['service'] = [
+                '@context' =>'http://iiif.io/api/search/0/context.json',
+                '@id' => $iiifSearch . $item->id(),
+                "profile" => "http://iiif.io/api/search/0/search",
+                "label" => "Search within this manifest"
+            ];
+        }
+
+
         /*
         // Omeka api is a service, but not referenced in https://iiif.io/api/annex/services.
         $manifest['service'] = [

--- a/src/View/Helper/IiifManifest.php
+++ b/src/View/Helper/IiifManifest.php
@@ -37,6 +37,7 @@ use Omeka\Api\Representation\ItemRepresentation;
 use Omeka\Api\Representation\MediaRepresentation;
 use Omeka\File\TempFileFactory;
 use Zend\View\Helper\AbstractHelper;
+use Omeka\Module\Manager as ModuleManager;
 
 class IiifManifest extends AbstractHelper
 {
@@ -159,11 +160,16 @@ class IiifManifest extends AbstractHelper
 
         $manifest['logo'] = $this->view->setting('iiifserver_manifest_logo_default');
 
-        $iiifSearch = $this->view->setting('iiifserver_manifest_service_iiifSearch');
+        $iiifSearch = $this->view->setting('iiifserver_manifest_service_iiifsearch');
+
         if ( $iiifSearch ) {
             $searchServiceAvailable = true;
-            $iiifSearchExtractOcr = $this->view->setting('iiifserver_manifest_service_iiifSearch_extractOcr');
-            if ($iiifSearchExtractOcr) {
+
+            $moduleManager = $item->getServiceLocator()->get('Omeka\ModuleManager');
+            $extractOcrModule = $moduleManager->getModule("ExtractOcr");
+
+            // Checking if module ExtractOcr is installed
+            if ($extractOcrModule->getState() == ModuleManager::STATE_ACTIVE) {
                 // Checking if item has at least an XML file that will allow search
                 $searchServiceAvailable = false;
                 foreach ( $item->media() as $media ) {

--- a/src/View/Helper/IiifManifest.php
+++ b/src/View/Helper/IiifManifest.php
@@ -30,6 +30,7 @@
 
 namespace IiifServer\View\Helper;
 
+use IiifSearch\View\Helper\IiifSearch;
 use IiifServer\Mvc\Controller\Plugin\TileInfo;
 use Omeka\Api\Representation\AbstractResourceEntityRepresentation;
 use Omeka\Api\Representation\ItemRepresentation;
@@ -160,12 +161,27 @@ class IiifManifest extends AbstractHelper
 
         $iiifSearch = $this->view->setting('iiifserver_manifest_service_iiifSearch');
         if ( $iiifSearch ) {
-            $manifest['service'] = [
-                '@context' =>'http://iiif.io/api/search/0/context.json',
-                '@id' => $iiifSearch . $item->id(),
-                "profile" => "http://iiif.io/api/search/0/search",
-                "label" => "Search within this manifest"
-            ];
+            $searchServiceAvailable = true;
+            $iiifSearchExtractOcr = $this->view->setting('iiifserver_manifest_service_iiifSearch_extractOcr');
+            if ($iiifSearchExtractOcr) {
+                // Checking if item has at least an XML file that will allow search
+                $searchServiceAvailable = false;
+                foreach ( $item->media() as $media ) {
+                    $mediaType = $media->mediaType();
+                    if (($mediaType == 'application/xml') || ($mediaType == 'text/xml')) {
+                        $searchServiceAvailable = true;
+                    }
+                }
+            }
+
+            if ($searchServiceAvailable) {
+                $manifest['service'] = [
+                    '@context' => 'http://iiif.io/api/search/0/context.json',
+                    '@id' => $iiifSearch . $item->id(),
+                    "profile" => "http://iiif.io/api/search/0/search",
+                    "label" => "Search within this manifest"
+                ];
+            }
         }
 
 


### PR DESCRIPTION
This PR adds two options to the config form : 
- an Url to an IIIF search service provider, to which the item id will be sent;
- a checkbox to tell IiifServer that the search service is provided by [IiifSearch](https://github.com/symac/Omeka-S-module-IiifSearch) and [extractOcr](https://github.com/symac/Omeka-S-module-ExtractOcr);

When an URL is set, IiifServer module will add a search service to the manifest. In case the checkbox is ticked, the module will first check if an XML file is attached to the item. It will prevent the search box to display on items where no OCR has been extracted and therefore no search results can be returned.