### PR TITLE
Fix 'context' and 'profile' url under 'service' property

### DIFF
--- a/src/View/Helper/IiifManifest2.php
+++ b/src/View/Helper/IiifManifest2.php
@@ -831,8 +831,7 @@ class IiifManifest2 extends AbstractHelper
 
         if ($service) {
             $imageUrlService = $this->view->iiifMediaUrl($media, 'imageserver/id', $service);
-            $imageResourceService = $this->_iiifImageService($imageUrlService, $service, $level);
-
+            $imageResourceService = $this->_iiifImageService($imageUrlService, 'http://iiif.io/api/image/2/context.json', 'http://iiif.io/api/image/2/profiles/level2.json');
             $iiifTileInfo = $view->iiifTileInfo($media);
             if ($iiifTileInfo) {
                 $imageResourceService->tiles = [$iiifTileInfo];


### PR DESCRIPTION
I set fixed url to correctly serve info.json file and like this, zoom function (for example) works correctly 
Tested and fixed on OmekaS ^3.0.1