### PR TITLE
Omekas 3.0 - fix manifest structure and UV reading

### DIFF
--- a/src/View/Helper/IiifManifest2.php
+++ b/src/View/Helper/IiifManifest2.php
@@ -831,8 +831,7 @@ class IiifManifest2 extends AbstractHelper
 
         if ($service) {
             $imageUrlService = $this->view->iiifMediaUrl($media, 'imageserver/id', $service);
-            $imageResourceService = $this->_iiifImageService($imageUrlService, $service, $level);
-
+            $imageResourceService = $this->_iiifImageService($imageUrlService, 'http://iiif.io/api/image/2/context.json', 'http://iiif.io/api/image/2/profiles/level2.json');
             $iiifTileInfo = $view->iiifTileInfo($media);
             if ($iiifTileInfo) {
                 $imageResourceService->tiles = [$iiifTileInfo];

--- a/src/View/Helper/IiifManifest2.php
+++ b/src/View/Helper/IiifManifest2.php
@@ -155,7 +155,9 @@ class IiifManifest2 extends AbstractHelper
         $metadata = $this->iiifMetadata($item);
         $manifest['metadata'] = $metadata;
 
+        // Don't use html in a title!
         $label = $this->view->escapeHtml($item->displayTitle('') ?: $manifest['@id']);
+        $label = html_entity_decode($label, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
         $manifest['label'] = $label;
 
         $descriptionProperty = $this->view->setting('iiifserver_manifest_description_property');


### PR DESCRIPTION

I set fixed url to correctly serve info.json file and like this, zoom function (for example) works correctly
Tested and fixed on OmekaS ^3.0.1