### PR TITLE
Fix: Form validation on optional, empty fields of types 'Element\Url' and 'OmekaElement\PropertySelect'

### DIFF
--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -1213,8 +1213,12 @@ class ConfigForm extends Form
         $addEvent = new Event('form.add_elements', $this);
         $this->getEventManager()->triggerEvent($addEvent);
 
-        // Use Laminas's input filter for URL validation on certain optional fields
+        // Fix optional fields whose element types default to required=true :
+        // - Field type 'Element\Url' uses a Uri validator that rejects empty strings.
+        // - Field type 'OmekaElement\PropertySelect' inherits required=true from Laminas Select.
+        // Both must be overridden so leaving a field empty does not abort saving the config form.
         $inputFilter = $this->getInputFilter();
+        // Field type 'Element\Url'
         foreach ([
             'iiifserver_media_api_url',
             'iiifserver_manifest_rights_url',
@@ -1224,8 +1228,18 @@ class ConfigForm extends Form
             $inputFilter->add([
                 'name' => $name,
                 'required' => false,
-                'allow_empty' => true, // Allow empty strings to pass Laminas Uri validation
+                'allow_empty' => true,
             ]);
+        }
+        // Field type 'OmekaElement\PropertySelect'
+        foreach ($this as $element) {
+            if ($element instanceof \Omeka\Form\Element\AbstractVocabularyMemberSelect) {
+                $inputFilter->add([
+                    'name' => $element->getName(),
+                    'required' => false,
+                    'allow_empty' => true,
+                ]);
+            }
         }
 
         $filterEvent = new Event('form.add_input_filters', $this, ['inputFilter' => $this->getInputFilter()]);

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -1213,6 +1213,21 @@ class ConfigForm extends Form
         $addEvent = new Event('form.add_elements', $this);
         $this->getEventManager()->triggerEvent($addEvent);
 
+        // Use Laminas's input filter for URL validation on certain optional fields
+        $inputFilter = $this->getInputFilter();
+        foreach ([
+            'iiifserver_media_api_url',
+            'iiifserver_manifest_rights_url',
+            'iiifserver_manifest_placeholder_canvas_default',
+            'iiifserver_manifest_logo_default',
+        ] as $name) {
+            $inputFilter->add([
+                'name' => $name,
+                'required' => false,
+                'allow_empty' => true, // Allow empty strings to pass Laminas Uri validation
+            ]);
+        }
+
         $filterEvent = new Event('form.add_input_filters', $this, ['inputFilter' => $this->getInputFilter()]);
         $this->getEventManager()->triggerEvent($filterEvent);
     }


### PR DESCRIPTION
## Note
This fix solves the issue described at https://github.com/Daniel-KM/Omeka-S-module-ImageServer/issues/9
I have used Copilot & Claude to investigate the issue and come with a fix. I have reviewed the code that was changed in the modules **ImageServer** and **IiifServer** and have tested it functionally in my Omeka S setup. I am satisfied with the result and hereby contribute the changed code to the upstream source code.
For module **ImageServer** I will create separate PR in which I will refer to both the issue and this PR.


## Problem
Submitting the module configuration form would silently fail to save any settings. The page would reload showing the previous unmodified values with no error message indicating what went wrong.

## Root cause
Both the **ImageServer** and **IiifServer** config forms used Laminas's `Element\Url` for optional URL fields. Laminas's `Element\Url` applies a `Uri` validator that **rejects empty strings** by default. When these optional fields were left blank (which is the initial state after the modules get installed), `$form->isValid()` returned `false`, causing `handleConfigFormAuto()` to return `false` — which prevents any settings from being saved. 
Because the Omeka core `ModuleController` only redirects on a truthy return value, the page simply re-rendered with the original settings and no visible error.

This regression was introduced when explicit `required => false` input filter specifications were removed from the forms.

## Fix
Added input filter specifications for all optional `Element\Url` fields to explicitly set `required => false` and `allow_empty => true`. This tells Laminas to skip URL validation when the field is empty, while still validating the URL format when a value is provided.

**ImageServer** (src/Form/ConfigForm.php):
- imageserver_info_rights_url

**IiifServer** (src/Form/ConfigForm.php):
- iiifserver_media_api_url
- iiifserver_manifest_rights_url
- iiifserver_manifest_placeholder_canvas_default
- iiifserver_manifest_logo_default
