### PR TITLE
Show the correct OCR page content in OCR helper plugin when using IIIF manifest API version 3

### DIFF
--- a/src/View/Helper/IiifAnnotationPageLine3.php
+++ b/src/View/Helper/IiifAnnotationPageLine3.php
@@ -52,8 +52,12 @@ class IiifAnnotationPageLine3 extends AbstractHelper
         $opts['callingResource'] = $resource;
         $opts['callingMotivation'] = 'annotation';
         $opts['isDereferenced'] = true;
-        // TODO Use TraitMediaInfo. Or filter medias first.
-        foreach ($resource->item()->media() as $media) {
+        // Filter the medias first and find the related OCR media for this page
+        // Then use that one as $mediasToSearch and create an AnnotationPage for it
+        // Fallback: if relatedOcr cannot be found, loop over all media for this item.
+        $relatedOcr = $this->view->iiifMediaRelatedOcr($resource, $index);
+        $mediasToSearch = $relatedOcr ? [$relatedOcr] : $resource->item()->media();
+        foreach ($mediasToSearch as $media) {
             $annotationPage = new AnnotationPage();
             $annotationPage
                 ->setOptions($opts)


### PR DESCRIPTION
This PR fixes an issue w.r.t. the OCR text that is shown in the Mirador OCR-helper panel.
With IIIF manifest API version 3, the OCR helper plugin always shows the OCR text of the first page, also if the user is on page 2, 3, 4 etc.
This does not happen with manifest version 2. There, the correct OCR text is being shown.

See screenshots below that demonstrate the issue.

### Before
<img width="1354" height="684" alt="31-OCR-page-1-orig" src="https://github.com/user-attachments/assets/fe7a4477-0eb6-4679-8bd8-12f86cd27cfd" />
<img width="1321" height="674" alt="31-OCR-page-2-orig" src="https://github.com/user-attachments/assets/ca4aa9b5-a11f-4530-a609-0f3eae77bf20" />




### After
<img width="1324" height="676" alt="32-OCR-page1-fixed" src="https://github.com/user-attachments/assets/cf3666e6-7fd4-4914-ae55-663297936e8c" />
<img width="1328" height="668" alt="32-OCR-page2-fixed" src="https://github.com/user-attachments/assets/7b3bdd75-1f96-4d96-803a-467fd5818483" />
